### PR TITLE
Task 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7271,6 +7271,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
+      "integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "enzyme-to-json": "^3.4.4",
     "formik": "^2.1.5",
     "formik-material-ui": "^2.0.1",
+    "http-status-codes": "^2.1.4",
     "lodash": "^4.17.19",
     "mime": "^2.4.6",
     "mime-types": "^2.1.27",

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -32,13 +32,15 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
   };
 
   const uploadFile = async (e: any) => {
-      // Get the presigned URL
+      const token = localStorage.getItem('Authorization');
+      const headers = token ? {'Authorization': token} : null;
       const response = await axios({
         method: 'GET',
         url,
         params: {
           name: encodeURIComponent(file.name)
-        }
+        },
+        headers
       })
       console.log('File to upload: ', file.name)
       console.log('Uploading to: ', response.data)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,14 +7,19 @@ import {Provider} from 'react-redux';
 import * as serviceWorker from './serviceWorker';
 import CssBaseline from "@material-ui/core/CssBaseline";
 import axios from 'axios';
+import {BAD_REQUEST, UNAUTHORIZED, FORBIDDEN} from 'http-status-codes';
 
 axios.interceptors.response.use(
   response => {
     return response;
   },
   function(error) {
-    if (error.response.status === 400) {
+    const responseStatus = error.response.status;
+    if (responseStatus === BAD_REQUEST) {
       alert(error.response.data?.data);
+    }
+    if (responseStatus === UNAUTHORIZED || responseStatus === FORBIDDEN) {
+      alert(error.response.data.message);
     }
     return Promise.reject(error.response);
   }


### PR DESCRIPTION
###  [Link to deploy](https://d1y5no422zd7ei.cloudfront.net/)
### [Link to BE PR](https://github.com/pavel-leskavets/shop-be/pull/5)

### Evaluation criteria
- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

### Additional (optional) tasks
- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file

### Final grade - 6 points

### Notes
`localStorage.setItem('Authorization', 'Basic cGF2ZWxMZXNrYXZldHM6VEVTVF9QQVNTV09SRA==')`
File
[ezyzip.zip](https://github.com/pavel-leskavets/nodejs-aws-fe/files/5611966/ezyzip.zip)

